### PR TITLE
Speed up the /api/v1/crypto response

### DIFF
--- a/shkeeper/api_v1.py
+++ b/shkeeper/api_v1.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 import traceback
 from os import environ
 from concurrent.futures import ThreadPoolExecutor
+from operator import  itemgetter
+
 
 from werkzeug.datastructures import Headers
 from flask import Blueprint, jsonify
@@ -72,8 +74,8 @@ def list_crypto():
 
     return {
         "status": "success",
-        "crypto": filtered_list,
-        "crypto_list": crypto_list,
+        "crypto": sorted(filtered_list),
+        "crypto_list": sorted(crypto_list, key=itemgetter("name")),
     }
 
 

--- a/shkeeper/api_v1.py
+++ b/shkeeper/api_v1.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 import traceback
 from os import environ
+from concurrent.futures import ThreadPoolExecutor
 
 from werkzeug.datastructures import Headers
 from flask import Blueprint, jsonify
@@ -44,14 +45,31 @@ bp = Blueprint("api_v1", __name__, url_prefix="/api/v1/")
 def list_crypto():
     filtered_list = []
     crypto_list = []
-    for crypto in Crypto.instances.values():
-        if crypto.wallet.enabled and (crypto.getstatus() != "Offline"):
-            if (not app.config.get("DISABLE_CRYPTO_WHEN_LAGS") or 
-                    (app.config.get("DISABLE_CRYPTO_WHEN_LAGS") and crypto.getstatus() == "Synced")):
-                filtered_list.append(crypto.crypto)
-                crypto_list.append(
-                    {"name": crypto.crypto, "display_name": crypto.display_name}
-                )
+    disable_on_lags = app.config.get("DISABLE_CRYPTO_WHEN_LAGS")
+    cryptos =  Crypto.instances.values()
+    filtered_cryptos = []
+
+    for crypto in cryptos:
+        if crypto.wallet.enabled:
+            filtered_cryptos.append(crypto)
+
+    def get_crypto_status(crypto):
+        return crypto, crypto.getstatus()
+
+    with ThreadPoolExecutor() as executor:
+        results = list(executor.map(get_crypto_status, filtered_cryptos))
+
+    for crypto, status in results:
+        if status == "Offline":
+            continue
+        if disable_on_lags and status != "Synced":
+            continue
+        filtered_list.append(crypto.crypto)
+        crypto_list.append({
+            "name": crypto.crypto,
+            "display_name": crypto.display_name
+        })
+
     return {
         "status": "success",
         "crypto": filtered_list,


### PR DESCRIPTION
Using parallel requests instead of sequential ones to check for cryptocurrency availability.