### PR TITLE
add block time to crypto api

### DIFF
--- a/shkeeper/api_v1.py
+++ b/shkeeper/api_v1.py
@@ -3,6 +3,7 @@ import traceback
 from os import environ
 from concurrent.futures import ThreadPoolExecutor
 from operator import  itemgetter
+import datetime
 
 
 from werkzeug.datastructures import Headers
@@ -56,12 +57,23 @@ def list_crypto():
             filtered_cryptos.append(crypto)
 
     def get_crypto_status(crypto):
-        return crypto, crypto.getstatus()
+        status_result = crypto.getstatus(True)
+        # 如果返回的是元组（包含状态和区块时间戳），则解包
+        if isinstance(status_result, tuple):
+            status, block_timestamp = status_result
+        else:
+            # 否则只有状态信息，区块时间戳为 None
+            status = status_result
+            block_timestamp = None
+        return crypto, status, block_timestamp
 
     with ThreadPoolExecutor() as executor:
         results = list(executor.map(get_crypto_status, filtered_cryptos))
 
-    for crypto, status in results:
+    # 获取服务器时间戳
+    server_timestamp = int(datetime.datetime.now().timestamp())
+
+    for crypto, status, block_timestamp in results:
         if status == "Offline":
             continue
         if disable_on_lags and status != "Synced":
@@ -69,13 +81,15 @@ def list_crypto():
         filtered_list.append(crypto.crypto)
         crypto_list.append({
             "name": crypto.crypto,
-            "display_name": crypto.display_name
+            "display_name": crypto.display_name,
+            "block_timestamp": block_timestamp
         })
 
     return {
         "status": "success",
         "crypto": sorted(filtered_list),
         "crypto_list": sorted(crypto_list, key=itemgetter("name")),
+        "server_timestamp": server_timestamp
     }
 
 

--- a/shkeeper/api_v1.py
+++ b/shkeeper/api_v1.py
@@ -58,20 +58,15 @@ def list_crypto():
 
     def get_crypto_status(crypto):
         status_result = crypto.getstatus(True)
-        # 如果返回的是元组（包含状态和区块时间戳），则解包
         if isinstance(status_result, tuple):
             status, block_timestamp = status_result
         else:
-            # 否则只有状态信息，区块时间戳为 None
             status = status_result
             block_timestamp = None
         return crypto, status, block_timestamp
 
     with ThreadPoolExecutor() as executor:
         results = list(executor.map(get_crypto_status, filtered_cryptos))
-
-    # 获取服务器时间戳
-    server_timestamp = int(datetime.datetime.now().timestamp())
 
     for crypto, status, block_timestamp in results:
         if status == "Offline":
@@ -84,6 +79,8 @@ def list_crypto():
             "display_name": crypto.display_name,
             "block_timestamp": block_timestamp
         })
+
+    server_timestamp = int(datetime.datetime.now().timestamp())
 
     return {
         "status": "success",

--- a/shkeeper/modules/classes/avalanche.py
+++ b/shkeeper/modules/classes/avalanche.py
@@ -36,7 +36,7 @@ class Avalanche(Ethereum):
         ).json(parse_float=Decimal)
         return response
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -48,9 +48,15 @@ class Avalanche(Ethereum):
             delta = abs(now_ts - block_ts)
             block_interval = 2
             if delta < block_interval * 10:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"

--- a/shkeeper/modules/classes/bnb.py
+++ b/shkeeper/modules/classes/bnb.py
@@ -36,7 +36,7 @@ class Bnb(Ethereum):
         ).json(parse_float=Decimal)
         return response
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -48,9 +48,15 @@ class Bnb(Ethereum):
             delta = abs(now_ts - block_ts)
             block_interval = 12
             if delta < block_interval * 10:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"

--- a/shkeeper/modules/classes/crypto.py
+++ b/shkeeper/modules/classes/crypto.py
@@ -86,7 +86,7 @@ class Crypto(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         pass
 
     @abc.abstractmethod

--- a/shkeeper/modules/classes/ethereum.py
+++ b/shkeeper/modules/classes/ethereum.py
@@ -65,7 +65,7 @@ class Ethereum(Crypto):
         ).json(parse_float=Decimal)
         return response
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -78,11 +78,17 @@ class Ethereum(Crypto):
             delta = abs(now_ts - block_ts)
             block_interval = 12
             if delta < block_interval * 10:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"
 
     def mkaddr(self, **kwargs):

--- a/shkeeper/modules/classes/polygon.py
+++ b/shkeeper/modules/classes/polygon.py
@@ -36,7 +36,7 @@ class Polygon(Ethereum):
         ).json(parse_float=Decimal)
         return response
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -48,9 +48,15 @@ class Polygon(Ethereum):
             delta = abs(now_ts - block_ts)
             block_interval = 2
             if delta < block_interval * 10:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"

--- a/shkeeper/modules/classes/solana.py
+++ b/shkeeper/modules/classes/solana.py
@@ -36,7 +36,7 @@ class Solana(Ethereum):
         ).json(parse_float=Decimal)
         return response
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -48,9 +48,15 @@ class Solana(Ethereum):
             delta = abs(now_ts - block_ts)
             block_interval = 1
             if delta < block_interval * 100:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"

--- a/shkeeper/modules/classes/tron_token.py
+++ b/shkeeper/modules/classes/tron_token.py
@@ -41,7 +41,7 @@ class TronToken(Crypto):
 
         return Decimal(balance)
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -54,11 +54,17 @@ class TronToken(Crypto):
             delta = abs(now_ts - block_ts)
             block_interval = 3
             if delta < block_interval * 10:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"
 
     def mkaddr(self, **kwargs):

--- a/shkeeper/modules/classes/xrp.py
+++ b/shkeeper/modules/classes/xrp.py
@@ -38,7 +38,7 @@ class Xrp(Ethereum):
         ).json(parse_float=Decimal)
         return response
 
-    def getstatus(self):
+    def getstatus(self, include_blocktime=False):
         try:
             response = requests.post(
                 f"http://{self.gethost()}/{self.crypto}/status",
@@ -53,9 +53,15 @@ class Xrp(Ethereum):
             delta = abs(now_ts - block_ts)
             block_interval = 4
             if delta < block_interval * 10:
-                return "Synced"
+                status = "Synced"
             else:
-                return "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+                status = "Sync In Progress (%d blocks behind)" % (delta // block_interval)
+
+            if include_blocktime:
+                return status, block_ts
+            return status
 
         except Exception as e:
+            if include_blocktime:
+                return "Offline", None
             return "Offline"


### PR DESCRIPTION
This PR adds a new health check endpoint to monitor the synchronization status of each cryptocurrency on the server. This endpoint is designed for alerting systems to detect when blockchain sync has stopped for an extended period.

Motivation
While the existing /metrics endpoint provides monitoring capabilities, it has some limitations:

The Prometheus format is difficult to parse for custom alerting scripts
The endpoint occasionally returns 500 errors with raw error text, making automated monitoring unreliable

Due to difficulties in setting up a complete testing environment, this PR has not been fully tested. I would appreciate code review and testing from maintainers before merging.

Please feel free to suggest any changes or improvements. Thank you for your consideration.