### PR TITLE
Fix USDT filtering

### DIFF
--- a/shkeeper/wallet.py
+++ b/shkeeper/wallet.py
@@ -222,6 +222,8 @@ def parts_transactions():
             field = getattr(Transaction, arg)
             if isinstance(field, property):
                 continue
+            elif "crypto" == arg:
+                query = query.filter(Transaction.crypto == request.args[arg])
             else:
                 query = query.filter(field.contains(request.args[arg]))
 


### PR DESCRIPTION
**Bug description**

If user selects USDT crypto, BNB-USDT is also shown

**Solution**

Replace contains by equals comparison 

**Note**

I do not have a setup to test this PR before merge, so it's not tested. Please test before merge, if you decide to merge.