### PR TITLE
fix(payouts): normalize coin addresses for task matching

### DIFF
--- a/shkeeper/models.py
+++ b/shkeeper/models.py
@@ -715,9 +715,9 @@ class Payout(db.Model):
                 payout.error = results
             db.session.commit()
             return
-        result_by_dest = {r["dest"]: r for r in results}
+        result_by_dest = {r["dest"].lower(): r for r in results}
         for payout in payouts:
-            r = result_by_dest.get(payout.dest_addr)
+            r = result_by_dest.get(payout.dest_addr.lower())
             if not r:
                 continue
             txids = r.get("txids", [])


### PR DESCRIPTION
- Convert all coin addresses to lowercase before comparing payout destination addresses with task results
- Ensure matches succeed regardless of checksum casing in the task response
- Prevent missed payouts for any supported cryptocurrency