### PR TITLE
Issue #154 upd: Use display name of the crypto for filtering transact…

### DIFF
--- a/shkeeper/modules/cryptos/avax.py
+++ b/shkeeper/modules/cryptos/avax.py
@@ -2,6 +2,8 @@ from shkeeper.modules.classes.avalanche import Avalanche
 
 
 class avax(Avalanche):
+    _display_name = "Avalanche AVAX"
+    
     def __init__(self):
         self.crypto = "AVAX"
 

--- a/shkeeper/modules/cryptos/bnb.py
+++ b/shkeeper/modules/cryptos/bnb.py
@@ -2,6 +2,8 @@ from shkeeper.modules.classes.bnb import Bnb
 
 
 class bnb(Bnb):
+    _display_name = "BNB Chain BNB"
+    
     def __init__(self):
         self.crypto = "BNB"
 

--- a/shkeeper/templates/wallet/transactions.j2
+++ b/shkeeper/templates/wallet/transactions.j2
@@ -185,7 +185,7 @@
             <option value="" disabled>Select crypto</option>
             <option value="" selected>Any crypto</option>
             {% for crypto in cryptos %}
-            <option value="{{crypto}}">{{crypto}}</option>
+              <option value="{{ crypto.value }}">{{ crypto.label }}</option>
             {% endfor %}
           </select>
         </div>

--- a/shkeeper/wallet.py
+++ b/shkeeper/wallet.py
@@ -210,7 +210,15 @@ def save_rates(fiat):
 def transactions():
     return render_template(
         "wallet/transactions.j2",
-        cryptos=Crypto.instances.keys(),
+        # cryptos=Crypto.instances.keys(),
+        cryptos = [
+          {
+              "value": crypto.getname(),
+              "label": crypto.display_name,
+          }
+          for crypto in Crypto.instances.values()
+        ],
+
         invoice_statuses=[status.name for status in InvoiceStatus],
     )
 


### PR DESCRIPTION
The /transactions handler now provides both the crypto identifier (used as value) and the human-readable display_name (used as label).
The dropdown renders display names (e.g. “Ethereum” instead of “ETH”) while preserving existing filtering logic based on internal crypto codes.