### PR TITLE
fix: convert satoshis to BTC before fee comparison in mkpayout (BTC/LTC autopayout broken)

### DIFF
--- a/shkeeper/modules/classes/btc.py
+++ b/shkeeper/modules/classes/btc.py
@@ -114,7 +114,7 @@ class Btc(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            fee = Decimal(self.estimate_tx_fee(amount)["fee"])
+            fee = Decimal(self.estimate_tx_fee(amount)["fee"]) / Decimal("100000000")
             if fee >= amount:
                 return f"Payout failed: not enought BTC to pay for transaction. Need {fee}, balance {amount}"
             else:


### PR DESCRIPTION
## Bug

Scheduled autopayout never executes for native coins (BTC, LTC). ERC-20 tokens (USDC, USDT, etc.) are unaffected.

### Root cause

`mkpayout()` in `shkeeper/modules/classes/btc.py` calls `estimate_tx_fee()`, which hits the sidecar's `/calc-tx-fee` endpoint. That endpoint returns `fee` in **satoshis** (e.g. `4220`). The code then compares it directly against `amount` in **BTC** (e.g. `0.197`):

```python
fee = Decimal(self.estimate_tx_fee(amount)["fee"])  # 4220 satoshis
if fee >= amount:  # 4220 >= 0.197 → always True
    return f"Payout failed: not enought BTC to pay for transaction. Need {fee}, balance {amount}"
```

Since `4220 >= 0.197` is always `True`, the method returns an error **string** instead of a dict. Back in `do_payout()` (models.py), the next line calls `res.get("task_id")` on that string, raising `AttributeError`. The exception is swallowed by the scheduler, `last_payout_attempt` has already been updated, and no `Payout` record is ever written — so the failure is completely silent.

### Why ERC-20 tokens are unaffected

The guard `if self.crypto == self.network_currency` is `False` for tokens (e.g. `ETH-USDC != ETH`), so the fee estimation branch is never entered.

### Evidence

- `calc-tx-fee` source confirms units: `fee = decimal_value_to_satoshi(w.get_transaction_price())` — explicitly converts to satoshis
- `fee_satoshi` field in the same response is `sat_per_kb_to_sat_per_vbyte(fee)` — a rate, not the total
- The downstream payout endpoint receives its fee via `get_transaction_price()` which returns a BTC-denominated float — confirming the expected unit after this fix
- `Payout` table contains zero BTC/LTC records despite `last_payout_attempt` being updated on schedule
- Issue #84 ("BTC Payout stuck") describes identical symptoms: autopayout reports insufficient funds, manual payouts succeed

## Fix

Divide the satoshi fee by `100_000_000` before the comparison and subtraction:

```python
fee = Decimal(self.estimate_tx_fee(amount)["fee"]) / Decimal("100000000")
```

This converts `4220 sat → 0.0000422 BTC`, making the comparison correct (`0.0000422 >= 0.197` → `False`) and the subtraction meaningful (`0.197 - 0.0000422 = 0.1969578 BTC`).

## Test

With the fix applied to a live deployment (shkeeper v2.5.17, bitcoin-shkeeper v2.0.13):
- BTC balance: 0.19767366 BTC, fee estimate: 4220 sat → 0.0000422 BTC
- LTC balance: 19.678 LTC, fee estimate: 1000 sat → 0.00001 LTC
- Both pass the `fee >= amount` check and proceed to payout