### PR TITLE
fix: route native-coin full payouts through sweep (BTC/LTC/DOGE autopayout)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,19 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      # These tests deliberately avoid importing the full Flask/DB app
+      # (they stub import deps), so no services are needed.
+      - name: Payout routing + webhook unit tests
+        run: |
+          python -m unittest tests.test_payout_policies tests.test_webhook_hmac -v

--- a/shkeeper/modules/classes/btc.py
+++ b/shkeeper/modules/classes/btc.py
@@ -114,11 +114,14 @@ class Btc(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            fee = Decimal(self.estimate_tx_fee(amount)["fee"])
-            if fee >= amount:
-                return f"Payout failed: not enought BTC to pay for transaction. Need {fee}, balance {amount}"
-            else:
-                amount -= fee
+            # Autopayout: hand the payout amount to the node-side wallet, which
+            # spends the UTXOs, computes the real size-aware fee, sends amount-fee
+            # to dest and keeps any reserve (balance-amount) as change.
+            response = requests.post(
+                f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}/{amount}",
+                auth=self.get_auth_creds(),
+            ).json(parse_float=Decimal)
+            return response
         current_fee = (
             fee
             if fee not in (None, 0, 0.0, "0", "")

--- a/shkeeper/modules/classes/btc.py
+++ b/shkeeper/modules/classes/btc.py
@@ -114,14 +114,16 @@ class Btc(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            # Autopayout: hand the payout amount to the node-side wallet, which
-            # spends the UTXOs, computes the real size-aware fee, sends amount-fee
-            # to dest and keeps any reserve (balance-amount) as change.
-            response = requests.post(
-                f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}/{amount}",
-                auth=self.get_auth_creds(),
-            ).json(parse_float=Decimal)
-            return response
+            # Autopayout fix (dual-path): full payout -> node-side sweep (real
+            # size-aware fee subtracted from amount); partial/reserve payout ->
+            # standard /payout below where the retained reserve covers the fee.
+            balance = self.balance()
+            if amount >= balance:
+                response = requests.post(
+                    f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}",
+                    auth=self.get_auth_creds(),
+                ).json(parse_float=Decimal)
+                return response
         current_fee = (
             fee
             if fee not in (None, 0, 0.0, "0", "")

--- a/shkeeper/modules/classes/doge.py
+++ b/shkeeper/modules/classes/doge.py
@@ -113,14 +113,16 @@ class Doge(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            # Autopayout: hand the payout amount to the node-side wallet, which
-            # spends the UTXOs, computes the real size-aware fee, sends amount-fee
-            # to dest and keeps any reserve (balance-amount) as change.
-            response = requests.post(
-                f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}/{amount}",
-                auth=self.get_auth_creds(),
-            ).json(parse_float=Decimal)
-            return response
+            # Autopayout fix (dual-path): full payout -> node-side sweep (real
+            # size-aware fee subtracted from amount); partial/reserve payout ->
+            # standard /payout below where the retained reserve covers the fee.
+            balance = self.balance()
+            if amount >= balance:
+                response = requests.post(
+                    f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}",
+                    auth=self.get_auth_creds(),
+                ).json(parse_float=Decimal)
+                return response
         current_fee = (
             fee
             if fee not in (None, 0, 0.0, "0", "")

--- a/shkeeper/modules/classes/doge.py
+++ b/shkeeper/modules/classes/doge.py
@@ -113,11 +113,14 @@ class Doge(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            fee = Decimal(self.estimate_tx_fee(amount)["fee"])
-            if fee >= amount:
-                return f"Payout failed: not enought BTC to pay for transaction. Need {fee}, balance {amount}"
-            else:
-                amount -= fee
+            # Autopayout: hand the payout amount to the node-side wallet, which
+            # spends the UTXOs, computes the real size-aware fee, sends amount-fee
+            # to dest and keeps any reserve (balance-amount) as change.
+            response = requests.post(
+                f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}/{amount}",
+                auth=self.get_auth_creds(),
+            ).json(parse_float=Decimal)
+            return response
         current_fee = (
             fee
             if fee not in (None, 0, 0.0, "0", "")

--- a/shkeeper/modules/classes/ltc.py
+++ b/shkeeper/modules/classes/ltc.py
@@ -113,11 +113,14 @@ class Ltc(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            fee = Decimal(self.estimate_tx_fee(amount)["fee"])
-            if fee >= amount:
-                return f"Payout failed: not enought BTC to pay for transaction. Need {fee}, balance {amount}"
-            else:
-                amount -= fee
+            # Autopayout: hand the payout amount to the node-side wallet, which
+            # spends the UTXOs, computes the real size-aware fee, sends amount-fee
+            # to dest and keeps any reserve (balance-amount) as change.
+            response = requests.post(
+                f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}/{amount}",
+                auth=self.get_auth_creds(),
+            ).json(parse_float=Decimal)
+            return response
         current_fee = (
             fee
             if fee not in (None, 0, 0.0, "0", "")

--- a/shkeeper/modules/classes/ltc.py
+++ b/shkeeper/modules/classes/ltc.py
@@ -113,14 +113,16 @@ class Ltc(Crypto):
 
     def mkpayout(self, destination, amount, fee, subtract_fee_from_amount=False):
         if self.crypto == self.network_currency and subtract_fee_from_amount:
-            # Autopayout: hand the payout amount to the node-side wallet, which
-            # spends the UTXOs, computes the real size-aware fee, sends amount-fee
-            # to dest and keeps any reserve (balance-amount) as change.
-            response = requests.post(
-                f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}/{amount}",
-                auth=self.get_auth_creds(),
-            ).json(parse_float=Decimal)
-            return response
+            # Autopayout fix (dual-path): full payout -> node-side sweep (real
+            # size-aware fee subtracted from amount); partial/reserve payout ->
+            # standard /payout below where the retained reserve covers the fee.
+            balance = self.balance()
+            if amount >= balance:
+                response = requests.post(
+                    f"http://{self.gethost()}/{self.crypto}/sweep-payout/{destination}",
+                    auth=self.get_auth_creds(),
+                ).json(parse_float=Decimal)
+                return response
         current_fee = (
             fee
             if fee not in (None, 0, 0.0, "0", "")

--- a/tests/test_payout_policies.py
+++ b/tests/test_payout_policies.py
@@ -1,0 +1,132 @@
+"""Unit tests for native-coin autopayout routing (dual-path mkpayout).
+
+Guards the regression fixed in btc.py/ltc.py/doge.py: the old code did a
+unit-confused `fee >= amount` check and returned an *error string* (crashing
+do_payout). The fix routes a full payout (amount >= balance) to the node-side
+/sweep-payout, and a partial/reserve payout (amount < balance) to the existing
+/payout (where the retained reserve covers the fee). No client-side fee math.
+
+Importing `shkeeper` pulls Flask/DB, so we stub the import deps and exercise the
+real mkpayout method on instances built with __new__ (bypassing the base
+__init__). Run: python3 -m unittest tests.test_payout_policies
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from decimal import Decimal
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+COINS = ("btc", "ltc", "doge")
+NETWORK_CCY = {"btc": "BTC", "ltc": "LTC", "doge": "DOGE"}
+
+
+def _install_stubs() -> mock.MagicMock:
+    """Inject minimal stand-ins so the coin modules import without the app."""
+    fake_requests = mock.MagicMock(name="shkeeper.requests")
+
+    shk = types.ModuleType("shkeeper")
+    shk.__path__ = []  # mark as package
+    shk.requests = fake_requests
+    sys.modules["shkeeper"] = shk
+
+    for name in ("shkeeper.modules", "shkeeper.modules.classes"):
+        m = types.ModuleType(name)
+        m.__path__ = []
+        sys.modules[name] = m
+
+    crypto_mod = types.ModuleType("shkeeper.modules.classes.crypto")
+
+    class Crypto:  # minimal base; real one pulls the world
+        instances: dict = {}
+
+    crypto_mod.Crypto = Crypto
+    sys.modules["shkeeper.modules.classes.crypto"] = crypto_mod
+
+    flask_mod = types.ModuleType("flask")
+    flask_mod.current_app = types.SimpleNamespace(
+        logger=types.SimpleNamespace(
+            warning=lambda *a, **k: None, info=lambda *a, **k: None
+        )
+    )
+    sys.modules["flask"] = flask_mod
+    return fake_requests
+
+
+def _load_coin(coin: str):
+    path = ROOT / "shkeeper" / "modules" / "classes" / f"{coin}.py"
+    spec = importlib.util.spec_from_file_location(f"_test_{coin}", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_instance(coin: str, balance: Decimal):
+    fake_requests = _install_stubs()
+    mod = _load_coin(coin)
+    cls = getattr(mod, coin.capitalize())  # Btc / Ltc / Doge
+    inst = cls.__new__(cls)
+    inst.crypto = NETWORK_CCY[coin]
+    inst.gethost = lambda: "sidecar:6000"
+    inst.get_auth_creds = lambda: ("shkeeper", "shkeeper")
+    inst.balance = lambda: balance
+    # requests.post(...).json(parse_float=...) -> a successful task dict
+    fake_requests.post.return_value.json.return_value = {"task_id": "T-OK"}
+    return cls, inst, fake_requests
+
+
+class TestDualPathRouting(unittest.TestCase):
+    def test_full_payout_routes_to_sweep(self) -> None:
+        for coin in COINS:
+            with self.subTest(coin=coin):
+                cls, inst, req = _make_instance(coin, balance=Decimal("0.5"))
+                # full payout: amount == balance (DISABLE reserve policy)
+                res = cls.mkpayout(inst, "ADDR", Decimal("0.5"), 0,
+                                   subtract_fee_from_amount=True)
+                url = req.post.call_args[0][0]
+                self.assertIn("/sweep-payout/ADDR", url)
+                self.assertNotIn("/payout/", url)  # not the standard payout route
+                self.assertEqual(res, {"task_id": "T-OK"})
+                self.assertIsInstance(res, dict)  # never an error string
+
+    def test_partial_payout_routes_to_standard_payout(self) -> None:
+        for coin in COINS:
+            with self.subTest(coin=coin):
+                cls, inst, req = _make_instance(coin, balance=Decimal("1.0"))
+                # reserve kept: amount < balance (AMOUNT/PERCENT policy)
+                res = cls.mkpayout(inst, "ADDR", Decimal("0.4"), "150",
+                                   subtract_fee_from_amount=True)
+                url = req.post.call_args[0][0]
+                self.assertIn("/payout/ADDR/", url)
+                self.assertNotIn("/sweep-payout/", url)
+                self.assertEqual(res, {"task_id": "T-OK"})
+
+    def test_returns_dict_not_error_string(self) -> None:
+        # The regression returned an f-string on every native autopayout.
+        for coin in COINS:
+            with self.subTest(coin=coin):
+                cls, inst, _ = _make_instance(coin, balance=Decimal("0.2"))
+                res = cls.mkpayout(inst, "ADDR", Decimal("0.2"), 0,
+                                   subtract_fee_from_amount=True)
+                self.assertNotIsInstance(res, str)
+
+
+class TestRegressionGuardStatic(unittest.TestCase):
+    """Fail loudly if the buggy fee-vs-amount block ever reappears."""
+
+    def test_no_fee_ge_amount_block(self) -> None:
+        for coin in COINS:
+            with self.subTest(coin=coin):
+                src = (ROOT / "shkeeper" / "modules" / "classes" / f"{coin}.py").read_text()
+                self.assertNotIn("if fee >= amount", src)
+                self.assertNotIn("not enought", src)  # the old error string
+                self.assertIn("/sweep-payout/", src)  # dual-path present
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem
Scheduled autopayout silently fails for native UTXO coins (BTC/LTC/DOGE) while ERC-20 tokens work. It's a **regression**: it worked when BTC used `bitcoin_like_crypto.py` (Bitcoin Core `sendtoaddress(..., subtractfeefromamount=True)` — the node did fee/UTXO/change). Commit `67c1e6c` ("add btc", first shipped in v2.4.0) introduced a `Btc` class with hand-rolled fee logic; LTC/DOGE copied it. Present through v2.5.19.

Root cause in `modules/classes/{btc,ltc,doge}.py mkpayout`: a unit-confused check — `fee = estimate_tx_fee(amount)["fee"]` (a **satoshi rate**) compared against `amount` (**coin units**) — is essentially always true, so it returns an **error string**, which `models.py do_payout` then crashes on (`res.get("task_id")`). No payout row is ever created.

### Fix — dual-path routing (no client-side fee math)
In `mkpayout` for native coins:
- **Full payout** (`amount >= balance`, i.e. DISABLE reserve) → POST the new sidecar `/<coin>/sweep-payout/<dest>`, which sweeps all UTXOs and subtracts the real size-aware fee (the modern equivalent of the old `sendtoaddress(subtractfeefromamount=True)`).
- **Partial / reserve payout** (`amount < balance`) → the buggy fee block is removed and the call falls through to the **existing, unmodified `/payout` path** (`make_multipayout` → `send_to`), where the retained reserve covers the fee. **No new logic is introduced for this branch** — the sweep changes apply only to full payouts.

`models.py` is untouched. Companion sidecar PR: vsys-host/bitcoin-shkeeper#65.

### Testing
- ✅ **Validated on mainnet** (2026-06-04, shkeeper 2.5.19 / bitcoin-shkeeper 2.0.13): triggered a scheduled full payout on a wallet with **multiple UTXOs**. Result — a real **multi-input, no-change sweep** that subtracted a size-aware fee from the amount, broadcast cleanly (no "Not enough unspent transaction outputs"), reported confirmations on the outgoing tx, and the payout reached **SUCCESS** after the required confirmations. *Exact txid can be shared privately with maintainers on request.*
- ✅ **Unit tests** (`tests/test_payout_policies.py`, CI): full→sweep / partial→/payout routing across BTC/LTC/DOGE, returns a dict (never an error string), plus a static guard against the `fee >= amount` block reappearing.
- ⚠️ **Honest scope:** the **partial/reserve path is routing-tested only (mocked)**, not end-to-end — it delegates to pre-existing, unchanged payout code. Full-sweep is the path proven on-chain.

Out of scope: ETH/EVM classes (different decimals; unaffected).
