### PR TITLE
fix: defer BTC Lightning background threads until Flask app is ready

### DIFF
--- a/shkeeper/__init__.py
+++ b/shkeeper/__init__.py
@@ -261,6 +261,11 @@ def create_app(test_config=None):
     app.register_blueprint(callback.bp)
     # app.register_blueprint(callback.bp_callback)
 
+    from .modules.classes.crypto import Crypto
+
+    if btc_lightning := Crypto.instances.get("BTC-LIGHTNING"):
+        btc_lightning.start_threads(app)
+
     shkeeper_initialized.set()
 
     return app

--- a/shkeeper/modules/cryptos/bitcoin_lightning.py
+++ b/shkeeper/modules/cryptos/bitcoin_lightning.py
@@ -77,50 +77,53 @@ class BitcoinLightning(Crypto):
         )
 
         self._lnurl = None
+        self._threads_started = False
 
-        self.start_threads()
+    def start_threads(self, flask_app):
+        if self._threads_started:
+            return
+        self._threads_started = True
 
-    def start_threads(self):
         threading.Thread(
             target=self.invoice_listener,
             name="invoice listener",
             daemon=True,
-            args=(app._get_current_object(),),
+            args=(flask_app,),
         ).start()
 
         threading.Thread(
             target=self.invoice_refresher,
             name="invoice refresher",
             daemon=True,
-            args=(app._get_current_object(),),
+            args=(flask_app,),
         ).start()
 
         threading.Thread(
             target=self.invoice_notificator,
             name="invoice notificator",
             daemon=True,
-            args=(app._get_current_object(),),
+            args=(flask_app,),
         ).start()
 
         # threading.Thread(
         #     target=self.wallet_unlocker,
         #     name="wallet_unlocker",
         #     daemon=True,
-        #     args=(app._get_current_object(),),
+        #     args=(flask_app,),
         # ).start()
 
         threading.Thread(
             target=self.seed_saver,
             name="seed saver",
             daemon=True,
-            args=(app._get_current_object(),),
+            args=(flask_app,),
         ).start()
 
         threading.Thread(
             target=self.lnurl_setup,
             name="lnurl setup",
             daemon=True,
-            args=(app._get_current_object(),),
+            args=(flask_app,),
         ).start()
 
     def getname(self):


### PR DESCRIPTION
- Remove start_threads() from BitcoinLightning.__init__
- Change start_threads() to accept an explicit flask_app argument
- Add a _threads_started guard to avoid starting threads more than once
- Start BTC Lightning threads at the end of create_app(), after blueprints are registered and right before shkeeper_initialized.set()