### PR TITLE
Rename MATIC to POL and TON to GRAM

### DIFF
--- a/shkeeper/modules/cryptos/matic.py
+++ b/shkeeper/modules/cryptos/matic.py
@@ -2,6 +2,8 @@ from shkeeper.modules.classes.polygon import Polygon
 
 
 class matic(Polygon):
+    _display_name = "POL (prev. MATIC)"
+
     def __init__(self):
         self.crypto = "MATIC"
 

--- a/shkeeper/modules/cryptos/ton.py
+++ b/shkeeper/modules/cryptos/ton.py
@@ -2,6 +2,8 @@ from shkeeper.modules.classes.ton import Ton
 
 
 class ton(Ton):
+    _display_name = "GRAM (prev. TON)"
+
     def __init__(self):
         self.crypto = "TON"
 

--- a/shkeeper/modules/rates/binance.py
+++ b/shkeeper/modules/rates/binance.py
@@ -34,6 +34,14 @@ class Binance(RateSource):
         if crypto == "OP-TOKEN":
             crypto = "OP"
 
+        # MATIC (native currency in Polygon renamed to POL)
+        if crypto == "MATIC":
+            crypto = "POL"
+
+        # TON (native currency in TON renamed to GRAM)
+        if crypto == "TON":
+            crypto = "GRAM"
+
         if fiat == "USD":
             fiat = "USDT"
 

--- a/shkeeper/modules/rates/coinbase.py
+++ b/shkeeper/modules/rates/coinbase.py
@@ -33,6 +33,14 @@ class Coinbase(RateSource):
         if crypto == "OP-TOKEN":
             crypto = "OP"
 
+        # MATIC (native currency in Polygon renamed to POL)
+        if crypto == "MATIC":
+            crypto = "POL"
+
+        # TON (native currency in TON renamed to GRAM) not implemented yet
+        # if crypto == "TON":
+        #     crypto = "GRAM"
+
         if fiat == "USD":
             fiat = "USDT"
             

--- a/shkeeper/modules/rates/kraken.py
+++ b/shkeeper/modules/rates/kraken.py
@@ -33,6 +33,14 @@ class Kraken(RateSource):
         if crypto == "OP-TOKEN":
             crypto = "OP"
 
+        # MATIC (native currency in Polygon renamed to POL)
+        if crypto == "MATIC":
+            crypto = "POL"
+
+        # TON (native currency in TON renamed to GRAM) not implemented yet
+        # if crypto == "TON":
+        #     crypto = "GRAM"
+
         if fiat == "USD":
             fiat = "USDT"
             

--- a/shkeeper/modules/rates/kucoin.py
+++ b/shkeeper/modules/rates/kucoin.py
@@ -34,6 +34,14 @@ class KuCoin(RateSource):
         if crypto == "OP-TOKEN":
             crypto = "OP"
 
+        # MATIC (native currency in Polygon renamed to POL)
+        if crypto == "MATIC":
+            crypto = "POL"
+
+        # TON (native currency in TON renamed to GRAM) 
+        if crypto == "TON":
+            crypto = "GRAM"
+
         # https://www.kucoin.com/docs/beginners/introduction
         url = f"https://api.kucoin.com/api/v1/prices?base={fiat}&currencies={crypto}"
         answer = requests.get(url)


### PR DESCRIPTION
Update asset names/tickers to reflect the current canonical naming used by the corresponding ecosystems