### PR TITLE
fix: register payouts without task_id

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: PYTHONPATH=. python -m pytest tests/ -v

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.5

--- a/shkeeper/models.py
+++ b/shkeeper/models.py
@@ -216,15 +216,10 @@ class Wallet(db.Model):
             res = crypto.mkpayout(
                 self.pdest, balance, self.pfee, subtract_fee_from_amount=True
             )
-        task_id = res.get("task_id")
-        app.logger.warning(f"payout do_payt create {res}")
-        Payout.add(
-            {
-                "dest": self.pdest,
-                "amount": balance,
-            },
+        Payout.register_from_mkpayout(
+            res,
+            {"dest": self.pdest, "amount": balance},
             self.crypto,
-            task_id=task_id,
         )
         return res
 
@@ -785,6 +780,103 @@ class Payout(db.Model):
                 db.session.add(ptx)
             db.session.commit()
         return p
+
+    @staticmethod
+    def _format_mkpayout_error(error):
+        if error is None:
+            return None
+        if isinstance(error, str):
+            return error
+        if isinstance(error, dict):
+            return error.get("message") or str(error)
+        return str(error)
+
+    @classmethod
+    def add_failed(cls, dest, amount, crypto, error=None, callback_url=None, external_id=None):
+        formatted_error = cls._format_mkpayout_error(error)
+        app.logger.warning(
+            f"[Payout.add_failed] crypto={crypto} dest={dest} amount={amount} "
+            f"external_id={external_id} error={formatted_error}"
+        )
+        p = cls(
+            dest_addr=dest,
+            amount=amount,
+            crypto=crypto,
+            status=PayoutStatus.FAIL,
+            success="No",
+            error=formatted_error,
+            callback_url=callback_url,
+            external_id=external_id or None,
+        )
+        db.session.add(p)
+        db.session.commit()
+        return p
+
+    @classmethod
+    def register_from_mkpayout(cls, res, payout, crypto, external_id=None):
+        dest = payout["dest"]
+        amount = payout["amount"]
+        callback_url = payout.get("callback_url")
+
+        log_ctx = f"crypto={crypto} dest={dest} amount={amount} external_id={external_id}"
+        app.logger.info(
+            f"[register_from_mkpayout] start {log_ctx} res_type={type(res).__name__} res={res}"
+        )
+
+        if isinstance(res, dict):
+            if res.get("error"):
+                app.logger.warning(
+                    f"[register_from_mkpayout] dict with error -> add_failed {log_ctx} error={res['error']}"
+                )
+                return cls.add_failed(
+                    dest,
+                    amount,
+                    crypto,
+                    error=res["error"],
+                    callback_url=callback_url,
+                    external_id=external_id,
+                )
+            task_id = res.get("task_id")
+            result = res.get("result")
+            if task_id or result:
+                txids = []
+                if result:
+                    txids = result if isinstance(result, list) else [result]
+                app.logger.info(
+                    f"[register_from_mkpayout] dict success -> add {log_ctx} task_id={task_id} txids={txids}"
+                )
+                return cls.add(
+                    {
+                        "dest": dest,
+                        "amount": amount,
+                        "callback_url": callback_url,
+                        "txids": txids,
+                    },
+                    crypto,
+                    task_id=task_id,
+                    external_id=external_id,
+                )
+            app.logger.warning(
+                f"[register_from_mkpayout] dict without error/task_id/result -> no record {log_ctx} res={res}"
+            )
+            return None
+        elif isinstance(res, str):
+            app.logger.warning(
+                f"[register_from_mkpayout] str response -> add_failed {log_ctx} error={res}"
+            )
+            return cls.add_failed(
+                dest,
+                amount,
+                crypto,
+                error=res,
+                callback_url=callback_url,
+                external_id=external_id,
+            )
+
+        app.logger.error(
+            f"[register_from_mkpayout] unexpected response type -> no record {log_ctx} res_type={type(res).__name__} res={res}"
+        )
+        return None
 
 
 class Notification(db.Model):

--- a/shkeeper/services/payout_service.py
+++ b/shkeeper/services/payout_service.py
@@ -86,27 +86,29 @@ class PayoutService:
             app.logger.error(f"[single_payout] mkpayout failed: {e}")
             raise
 
-        task_id = res.get("task_id")
-        txids = res.get("result", [])
-        app.logger.info(f"[single_payout] mkpayout response: task_id={task_id} txids={txids} full_response={res}")
-
-        if not task_id:
-            app.logger.warning(f"[single_payout] No task_id returned from mkpayout — payout will rely on txid-based confirmation only")
-
-        if not txids:
-            app.logger.warning(f"[single_payout] No txids in mkpayout result — PayoutTx will be empty until task resolves")
+        app.logger.info(f"[single_payout] mkpayout response: {res}")
 
         try:
-            payout = cls.create_payout_record(req, crypto_name, task_id=task_id, txids=txids)
-            app.logger.info(f"[single_payout] Payout record created: payout_id={payout.id} task_id={task_id} txids={txids}")
+            payout = Payout.register_from_mkpayout(
+                res,
+                {
+                    "dest": req["destination"],
+                    "amount": Decimal(req["amount"]),
+                    "callback_url": callback_url,
+                },
+                crypto_name,
+                external_id=req.get("external_id"),
+            )
         except Exception as e:
             app.logger.error(f"[single_payout] Failed to create payout record: {e}")
             raise
 
-        if req.get("external_id"):
+        if req.get("external_id") and isinstance(res, dict):
             res["external_id"] = req["external_id"]
 
-        app.logger.info(f"[single_payout] Completed successfully: payout_id={payout.id} external_id={res.get('external_id')} task_id={task_id}")
+        app.logger.info(
+            f"[single_payout] Completed: payout_id={payout.id if payout else None} res={res}"
+        )
         return res
 
     @classmethod

--- a/tests/test_payout_register.py
+++ b/tests/test_payout_register.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import unittest
+from decimal import Decimal
+from unittest import mock
+
+from flask import Flask
+
+from shkeeper.models import Payout, PayoutStatus
+
+
+class _AppContextTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._flask_app = Flask(__name__)
+        self._app_ctx = self._flask_app.app_context()
+        self._app_ctx.push()
+        self.addCleanup(self._app_ctx.pop)
+
+
+class TestFormatMkpayoutError(unittest.TestCase):
+    def test_none_returns_none(self) -> None:
+        self.assertIsNone(Payout._format_mkpayout_error(None))
+
+    def test_string_returned_as_is(self) -> None:
+        self.assertEqual(Payout._format_mkpayout_error("boom"), "boom")
+
+    def test_dict_with_message_uses_message(self) -> None:
+        self.assertEqual(
+            Payout._format_mkpayout_error({"message": "not enough funds", "code": 5}),
+            "not enough funds",
+        )
+
+    def test_dict_without_message_stringifies(self) -> None:
+        err = {"code": 5}
+        self.assertEqual(Payout._format_mkpayout_error(err), str(err))
+
+    def test_dict_with_empty_message_falls_back_to_str(self) -> None:
+        err = {"message": "", "code": 5}
+        self.assertEqual(Payout._format_mkpayout_error(err), str(err))
+
+    def test_non_str_non_dict_stringifies(self) -> None:
+        self.assertEqual(Payout._format_mkpayout_error(500), "500")
+
+
+class TestAddFailed(_AppContextTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.db_patcher = mock.patch("shkeeper.models.db")
+        self.db = self.db_patcher.start()
+        self.addCleanup(self.db_patcher.stop)
+
+    def test_creates_failed_record_and_persists(self) -> None:
+        p = Payout.add_failed(
+            dest="addr1",
+            amount=Decimal("1.5"),
+            crypto="BTC",
+            error="node offline",
+            callback_url="https://cb.example/hook",
+            external_id="ext-1",
+        )
+        self.assertEqual(p.dest_addr, "addr1")
+        self.assertEqual(p.amount, Decimal("1.5"))
+        self.assertEqual(p.crypto, "BTC")
+        self.assertEqual(p.status, PayoutStatus.FAIL)
+        self.assertEqual(p.success, "No")
+        self.assertEqual(p.error, "node offline")
+        self.assertEqual(p.callback_url, "https://cb.example/hook")
+        self.assertEqual(p.external_id, "ext-1")
+        self.db.session.add.assert_called_once_with(p)
+        self.db.session.commit.assert_called_once()
+
+    def test_dict_error_is_formatted(self) -> None:
+        p = Payout.add_failed(
+            dest="addr1",
+            amount=Decimal("1"),
+            crypto="LTC",
+            error={"message": "insufficient funds"},
+        )
+        self.assertEqual(p.error, "insufficient funds")
+
+    def test_empty_external_id_normalized_to_none(self) -> None:
+        p = Payout.add_failed(dest="a", amount=Decimal("1"), crypto="BTC", external_id="")
+        self.assertIsNone(p.external_id)
+
+    def test_missing_error_is_none(self) -> None:
+        p = Payout.add_failed(dest="a", amount=Decimal("1"), crypto="BTC")
+        self.assertIsNone(p.error)
+
+
+class TestRegisterFromMkpayout(_AppContextTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.add_patcher = mock.patch.object(Payout, "add")
+        self.add_failed_patcher = mock.patch.object(Payout, "add_failed")
+        self.add = self.add_patcher.start()
+        self.add_failed = self.add_failed_patcher.start()
+        self.addCleanup(self.add_patcher.stop)
+        self.addCleanup(self.add_failed_patcher.stop)
+
+        self.payout = {
+            "dest": "addr1",
+            "amount": Decimal("2"),
+            "callback_url": "https://cb.example/hook",
+        }
+
+    def test_dict_with_error_routes_to_add_failed(self) -> None:
+        res = {"error": "boom"}
+        out = Payout.register_from_mkpayout(res, self.payout, "BTC", external_id="ext-1")
+
+        self.add_failed.assert_called_once_with(
+            "addr1",
+            Decimal("2"),
+            "BTC",
+            error="boom",
+            callback_url="https://cb.example/hook",
+            external_id="ext-1",
+        )
+        self.add.assert_not_called()
+        self.assertIs(out, self.add_failed.return_value)
+
+    def test_dict_with_task_id_only_routes_to_add(self) -> None:
+        res = {"task_id": "task-123"}
+        out = Payout.register_from_mkpayout(res, self.payout, "BTC", external_id="ext-1")
+
+        self.add.assert_called_once_with(
+            {
+                "dest": "addr1",
+                "amount": Decimal("2"),
+                "callback_url": "https://cb.example/hook",
+                "txids": [],
+            },
+            "BTC",
+            task_id="task-123",
+            external_id="ext-1",
+        )
+        self.add_failed.assert_not_called()
+        self.assertIs(out, self.add.return_value)
+
+    def test_dict_result_list_kept_as_txids(self) -> None:
+        res = {"task_id": "t1", "result": ["tx1", "tx2"]}
+        Payout.register_from_mkpayout(res, self.payout, "BTC")
+
+        payout_arg = self.add.call_args.args[0]
+        self.assertEqual(payout_arg["txids"], ["tx1", "tx2"])
+        self.assertEqual(self.add.call_args.kwargs["task_id"], "t1")
+
+    def test_dict_result_scalar_wrapped_in_list(self) -> None:
+        res = {"result": "tx-single"}
+        Payout.register_from_mkpayout(res, self.payout, "BTC")
+
+        payout_arg = self.add.call_args.args[0]
+        self.assertEqual(payout_arg["txids"], ["tx-single"])
+        self.assertIsNone(self.add.call_args.kwargs["task_id"])
+
+    def test_dict_result_only_routes_to_add(self) -> None:
+        res = {"result": ["tx1"]}
+        out = Payout.register_from_mkpayout(res, self.payout, "BTC")
+        self.add.assert_called_once()
+        self.assertIs(out, self.add.return_value)
+
+    def test_empty_dict_creates_no_record(self) -> None:
+        out = Payout.register_from_mkpayout({}, self.payout, "BTC")
+        self.assertIsNone(out)
+        self.add.assert_not_called()
+        self.add_failed.assert_not_called()
+
+    def test_dict_without_relevant_keys_creates_no_record(self) -> None:
+        out = Payout.register_from_mkpayout({"foo": "bar"}, self.payout, "BTC")
+        self.assertIsNone(out)
+        self.add.assert_not_called()
+        self.add_failed.assert_not_called()
+
+    def test_string_response_routes_to_add_failed(self) -> None:
+        out = Payout.register_from_mkpayout("some error", self.payout, "BTC", external_id="ext-9")
+
+        self.add_failed.assert_called_once_with(
+            "addr1",
+            Decimal("2"),
+            "BTC",
+            error="some error",
+            callback_url="https://cb.example/hook",
+            external_id="ext-9",
+        )
+        self.add.assert_not_called()
+        self.assertIs(out, self.add_failed.return_value)
+
+    def test_none_response_creates_no_record(self) -> None:
+        out = Payout.register_from_mkpayout(None, self.payout, "BTC")
+        self.assertIsNone(out)
+        self.add.assert_not_called()
+        self.add_failed.assert_not_called()
+
+    def test_unexpected_type_creates_no_record(self) -> None:
+        out = Payout.register_from_mkpayout(["tx1"], self.payout, "BTC")
+        self.assertIsNone(out)
+        self.add.assert_not_called()
+        self.add_failed.assert_not_called()
+
+    def test_missing_callback_url_defaults_to_none(self) -> None:
+        payout = {"dest": "addr1", "amount": Decimal("2")}
+        Payout.register_from_mkpayout({"task_id": "t1"}, payout, "BTC")
+        payout_arg = self.add.call_args.args[0]
+        self.assertIsNone(payout_arg["callback_url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add Payout.register_from_mkpayout() to centralize payout recording from mkpayout responses (dict success, dict error, string error)
- Add Payout.add_failed() and _format_mkpayout_error() to persist failed payouts with a normalized error message
- Route Wallet.do_payout() and PayoutService.single_payout() through register_from_mkpayout() instead of duplicating task_id/txids handling