### PR TITLE
fix: reserve payout records before wallet calls

### DIFF
--- a/shkeeper/models.py
+++ b/shkeeper/models.py
@@ -10,6 +10,8 @@ import bcrypt
 import pyotp
 from flask import current_app as app, has_app_context
 
+from sqlalchemy.exc import IntegrityError
+
 from shkeeper import db
 from shkeeper.modules.classes.rate_source import RateSource
 from shkeeper.modules.classes.crypto import Crypto
@@ -780,7 +782,7 @@ class Payout(db.Model):
             external_id=external_id,
         )
         db.session.add(p)
-        db.session.commit()
+        cls._commit_or_raise_duplicate_external_id(external_id, crypto)
         txids = payout.get("txids")
         if txids:
             if isinstance(txids, str):
@@ -790,6 +792,22 @@ class Payout(db.Model):
                 db.session.add(ptx)
             db.session.commit()
         return p
+
+    @classmethod
+    def _commit_or_raise_duplicate_external_id(cls, external_id, crypto=None):
+        try:
+            db.session.commit()
+        except IntegrityError as e:
+            db.session.rollback()
+            if external_id:
+                q = cls.query.filter_by(external_id=external_id)
+                if crypto:
+                    q = q.filter_by(crypto=crypto)
+                if q.first() is not None:
+                    raise ValueError(
+                        f"Payout with this external_id already exists: {external_id}"
+                    ) from e
+            raise
 
     @staticmethod
     def _format_mkpayout_error(error):
@@ -821,7 +839,7 @@ class Payout(db.Model):
             external_id=external_id or None,
         )
         db.session.add(p)
-        db.session.commit()
+        cls._commit_or_raise_duplicate_external_id(external_id or None, crypto)
         return p
 
     @classmethod
@@ -891,6 +909,66 @@ class Payout(db.Model):
             f"[register_from_mkpayout] unexpected response type -> no record {log_ctx} res_type={type(res).__name__} res={res}"
         )
         return None
+
+    def _mark_failed(self, error):
+        self.status = PayoutStatus.FAIL
+        self.success = "No"
+        self.error = self._format_mkpayout_error(error)
+        db.session.commit()
+        return self
+
+    def apply_mkpayout_response(self, res):
+        log_ctx = (
+            f"payout_id={self.id} crypto={self.crypto} dest={self.dest_addr} "
+            f"amount={self.amount} external_id={self.external_id}"
+        )
+        app.logger.info(
+            f"[apply_mkpayout_response] start {log_ctx} "
+            f"res_type={type(res).__name__} res={res}"
+        )
+
+        if isinstance(res, dict):
+            if res.get("error"):
+                app.logger.warning(
+                    f"[apply_mkpayout_response] dict with error -> FAIL {log_ctx} "
+                    f"error={res['error']}"
+                )
+                return self._mark_failed(res["error"])
+            task_id = res.get("task_id")
+            result = res.get("result")
+            if task_id or result:
+                if task_id:
+                    self.task_id = task_id
+                txids = []
+                if result:
+                    txids = result if isinstance(result, list) else [result]
+                app.logger.info(
+                    f"[apply_mkpayout_response] success {log_ctx} "
+                    f"task_id={task_id} txids={txids}"
+                )
+                for txid in txids:
+                    if not any(t.txid == txid for t in self.transactions):
+                        db.session.add(PayoutTx(payout_id=self.id, txid=txid))
+                db.session.commit()
+                return self
+            message = f"Unexpected mkpayout response (missing error/task_id/result): {res}"
+            app.logger.warning(
+                f"[apply_mkpayout_response] dict without error/task_id/result "
+                f"-> FAIL {log_ctx} res={res}"
+            )
+            return self._mark_failed(message)
+        elif isinstance(res, str):
+            app.logger.warning(
+                f"[apply_mkpayout_response] str response -> FAIL {log_ctx} error={res}"
+            )
+            return self._mark_failed(res)
+
+        message = f"Unexpected mkpayout response type {type(res).__name__}: {res}"
+        app.logger.error(
+            f"[apply_mkpayout_response] unexpected response type -> FAIL {log_ctx} "
+            f"res_type={type(res).__name__} res={res}"
+        )
+        return self._mark_failed(message)
 
 
 class Notification(db.Model):

--- a/shkeeper/services/payout_service.py
+++ b/shkeeper/services/payout_service.py
@@ -3,8 +3,9 @@ from decimal import Decimal
 from urllib.parse import urlparse
 from flask import current_app as app
 from shkeeper import db
-from shkeeper.models import Payout
+from shkeeper.models import Payout, PayoutStatus
 from shkeeper.modules.classes.crypto import Crypto
+
 
 class PayoutService:
     @staticmethod
@@ -49,6 +50,19 @@ class PayoutService:
             external_id=req.get("external_id")
         )
 
+    @staticmethod
+    def _mark_reserved_failed(payouts, error):
+        if not payouts:
+            return
+        message = Payout._format_mkpayout_error(error)
+        if message is None:
+            message = str(error)
+        for payout in payouts:
+            payout.status = PayoutStatus.FAIL
+            payout.success = "No"
+            payout.error = message
+        db.session.commit()
+
     @classmethod
     def single_payout(cls, crypto_name, req):
         app.logger.info(f"[single_payout] Started for crypto={crypto_name} destination={req.get('destination')} amount={req.get('amount')} external_id={req.get('external_id')}")
@@ -75,6 +89,15 @@ class PayoutService:
             app.logger.error(f"[single_payout] Invalid callback_url={callback_url!r}: {e}")
             raise
 
+        try:
+            payout = cls.create_payout_record(req, crypto_name, task_id=None)
+            app.logger.info(
+                f"[single_payout] Reserved payout_id={payout.id} external_id={req.get('external_id')}"
+            )
+        except Exception as e:
+            app.logger.error(f"[single_payout] Failed to reserve payout record: {e}")
+            raise
+
         app.logger.info(f"[single_payout] Calling mkpayout: destination={req['destination']} amount={req['amount']} fee={req['fee']}")
         try:
             res = crypto.mkpayout(
@@ -84,24 +107,11 @@ class PayoutService:
             )
         except Exception as e:
             app.logger.error(f"[single_payout] mkpayout failed: {e}")
+            cls._mark_reserved_failed([payout], e)
             raise
 
         app.logger.info(f"[single_payout] mkpayout response: {res}")
-
-        try:
-            payout = Payout.register_from_mkpayout(
-                res,
-                {
-                    "dest": req["destination"],
-                    "amount": Decimal(req["amount"]),
-                    "callback_url": callback_url,
-                },
-                crypto_name,
-                external_id=req.get("external_id"),
-            )
-        except Exception as e:
-            app.logger.error(f"[single_payout] Failed to create payout record: {e}")
-            raise
+        payout.apply_mkpayout_response(res)
 
         if req.get("external_id") and isinstance(res, dict):
             res["external_id"] = req["external_id"]
@@ -116,19 +126,57 @@ class PayoutService:
         if not isinstance(payout_list, list):
             raise ValueError("Expected an array of payouts")
 
-        crypto = cls.get_crypto(crypto_name)
-        res = crypto.multipayout(payout_list)
-        task_id = res.get("task_id")
-
-        created_ids = []
+        seen = set()
         for req in payout_list:
-            cls.check_external_id_unique(req, crypto_name)
-            cls.validate_callback_url(req.get("callback_url"))
-            payout = cls.create_payout_record(req, crypto_name, task_id=task_id)
-            created_ids.append(payout.id)
-        res["external_ids"] = [
-            req.get("external_id")
-            for req in payout_list
-            if req.get("external_id")
-        ]
+            external_id = req.get("external_id")
+            if not external_id:
+                continue
+            if external_id in seen:
+                raise ValueError(f"Duplicate external_id in payout batch: {external_id}")
+            seen.add(external_id)
+
+        crypto = cls.get_crypto(crypto_name)
+
+        reserved = []
+        try:
+            for req in payout_list:
+                cls.check_external_id_unique(req, crypto_name)
+                reserved.append(cls.create_payout_record(req, crypto_name, task_id=None))
+        except Exception:
+            if reserved:
+                for payout in reserved:
+                    db.session.delete(payout)
+                db.session.commit()
+            raise
+
+        try:
+            res = crypto.multipayout(payout_list)
+        except Exception as e:
+            cls._mark_reserved_failed(reserved, e)
+            raise
+
+        error = None
+        if isinstance(res, dict):
+            err = res.get("error")
+            if err:
+                error = err
+            elif res.get("status") == "error":
+                error = res.get("message") or res
+        elif isinstance(res, str):
+            error = res
+
+        if error is not None:
+            cls._mark_reserved_failed(reserved, error)
+        else:
+            task_id = res.get("task_id") if isinstance(res, dict) else None
+            if task_id:
+                for payout in reserved:
+                    payout.task_id = task_id
+                db.session.commit()
+        if isinstance(res, dict):
+            res["external_ids"] = [
+                req.get("external_id")
+                for req in payout_list
+                if req.get("external_id")
+            ]
         return res


### PR DESCRIPTION
- Add Payout.apply_mkpayout_response() to update an existing payout from mkpayout (dict success, dict error, string error) instead of creating a new record after the call
- Add Payout._commit_or_raise_duplicate_external_id() to turn IntegrityError on commit into a clear duplicate external_id error
- Add PayoutService._mark_reserved_failed() to persist FAIL on reserved payouts when mkpayout/multipayout throws or returns an error